### PR TITLE
[VEG-1592] Update the email field in manifest.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sdk_repl_app",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sdk_repl_app",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/preset-env": "^7.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdk_repl_app",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "An interactive programming environment for ZAF SDK v2 developers",
   "repository": {
     "type": "git",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "name": "v2 REPL",
   "author": {
     "name": "Zendesk",
-    "email": "https://support.zendesk.com/hc/en-us/articles/4408843597850-Contacting-Zendesk-Customer-Support",
+    "email": "https://www.zendesk.com/marketplace/apps/support/101101/v2-repl/?help_widget=true",
     "url": "https://www.zendesk.com"
   },
   "defaultLocale": "en",
@@ -39,6 +39,6 @@
       "email_editor": "assets/iframe.html"
     }
   },
-  "version": "2.0.8",
+  "version": "2.0.9",
   "frameworkVersion": "2.0"
 }


### PR DESCRIPTION
Update email in [v2_repl_app/manifest.json at master · zendesk/v2_repl_app](https://github.com/zendesk/v2_repl_app/blob/master/src/manifest.json) to follow the format of `https://<zam listing url>/?help_widget=true` and bump version to `2.0.9` 