### PR TITLE
Add support for "client" in REPL

### DIFF
--- a/src/javascripts/app.js
+++ b/src/javascripts/app.js
@@ -186,6 +186,10 @@ var App = {
 
       try {
         var input = $script.val().trim()
+        var regex = new RegExp(/\bclient\b/)
+        if(regex.test(input) === true ){
+           input = input.replace(regex, 'zafClient')
+        }
         var value = eval(input)
 
         if (!input) { return }


### PR DESCRIPTION
CC: @zendesk/vegemite

This is based off of a [request](https://zendesk-platform.slack.com/archives/C1MKJQF5Y/p1680188477575899) in the platform-dev slack instance. 

**Problem:**

In our dev docs all of our ZAF example calls use "client" instead of zafClient. 

e.g. 

```
var client = ZAFClient.init();
client.context().then(function(context) {
  console.log(context);
  /*
    {
      "instanceGuid": "7712c893-bec7-4e00-9db0-87fbb0c12914",
      "product": "support",
      "account": {
        "subdomain": "mondocam"
      },
      "location": 'ticket_sidebar',
      "ticketId": 1234
    }
  */
});
```

This makes it so that users can't just copy and paste our examples into REPL to test things. 


**Solution:**

In this PR I've written a small if statement that uses a regex word boundary to check if "client" is part of the input. If it is, then it replaces it with zafClient. This allows users to copy and paste our examples into REPL and have them function as expected. 
